### PR TITLE
Get pdfbox2-layout from MuleSoft repository

### DIFF
--- a/docdoku-plm-server-office-doc/pom.xml
+++ b/docdoku-plm-server-office-doc/pom.xml
@@ -13,8 +13,9 @@
 
     <repositories>
         <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
+            <id>mulesoft-releases</id>
+            <name>MuleSoft Repository</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
As version 1.0.0 is no longer available from jitpack (see #1) get it from MuleSoft repository as recommended in https://github.com/grasshopper7/extentreports-cucumber6-adapter/issues/36#issuecomment-817551411

Closes #1 