### PR TITLE
Update pdfbox version from 2.0.8 to 2.0.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox</artifactId>
-                <version>2.0.8</version>
+                <version>2.0.22</version>
             </dependency>
             <!-- pdfbox layout-->
             <dependency>


### PR DESCRIPTION
According to https://github.com/grasshopper7/extentreports-cucumber6-adapter/issues/36#issuecomment-817551411 version `2.0.22` is required.