### PR TITLE
Get pdfbox2-layout from jitpack.io repository

### DIFF
--- a/docdoku-plm-server-office-doc/pom.xml
+++ b/docdoku-plm-server-office-doc/pom.xml
@@ -13,9 +13,8 @@
 
     <repositories>
         <repository>
-            <id>mulesoft-releases</id>
-            <name>MuleSoft Repository</name>
-            <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
             <dependency>
                 <groupId>com.github.ralfstuckert.pdfbox-layout</groupId>
                 <artifactId>pdfbox2-layout</artifactId>
-                <version>1.0.0</version>
+                <version>1.0.1</version>
             </dependency>
 
             <!-- Test -->


### PR DESCRIPTION
As dependency is no longer available from https://repository.mulesoft.org/nexus/content/repositories/public/com/github/ralfstuckert/pdfbox-layout/pdfbox2-layout/ get it from https://nexus.pentaho.org/service/rest/repository/browse/proxy-public-3rd-party-release/com/github/ralfstuckert/pdfbox-layout/pdfbox2-layout/1.0.0/

This is a PR similar to #2 and hopefully fix (again) #1 